### PR TITLE
Rewrite dragging/measuring logic

### DIFF
--- a/app/assets/javascripts/pageflow/timeline_page/components/timeline_item_editor_menu.jsx
+++ b/app/assets/javascripts/pageflow/timeline_page/components/timeline_item_editor_menu.jsx
@@ -6,20 +6,21 @@
   class TimelineItemEditorMenu extends React.Component {
     constructor(props) {
       super(props);
-      this.state = {};
+      this.state = {
+        top: 0
+      };
     }
 
     render() {
       var {Draggable} = pageflow.react.components;
 
-      var start = {x: 0, y: this.props.top || 0};
+      var position = {x: 0, y: this.state.top};
       var bounds = {left: 0, right: 0, top: 0, bottom: 1000};
 
       return (
-        <Draggable start={start}
+        <Draggable position={position}
                    grid={[5, 5]}
                    bounds={bounds}
-                   moveOnStartChange={this.state.topChanged}
                    handle=".timeline_item_editor_menu-handle"
                    onStart={this._handleDragStart.bind(this)}
                    onDrag={this._handleDrag.bind(this)}
@@ -43,21 +44,24 @@
     }
 
     componentWillReceiveProps(nextProps) {
-      this.setState({
-        topChanged: (nextProps.top !== this.props.top)
-      });
+      if (nextProps.top !== this.props.top) {
+        this.setState({
+          top: nextProps.top
+        });
+      }
     }
 
     _handleDragStart() {
       this.context.pageScroller.disable();
     }
 
-    _handleDrag(event, ui) {
-      this.props.onDrag(ui.position.top);
+    _handleDrag(event, dragEvent) {
+      this.setState({top: dragEvent.y});
+      this.props.onDrag(dragEvent.y);
     }
 
-    _handleDragStop(event, ui) {
-      this.props.onDragStop(ui.position.top);
+    _handleDragStop(event, dragEvent) {
+      this.props.onDragStop(dragEvent.y);
       this.context.pageScroller.enable();
     }
 

--- a/app/assets/javascripts/pageflow/timeline_page/components/timeline_item_spacer.jsx
+++ b/app/assets/javascripts/pageflow/timeline_page/components/timeline_item_spacer.jsx
@@ -9,25 +9,22 @@
     }
 
     render() {
-      var {TimelineItemEditorMenu} = pageflow.timelinePage;
+      const {TimelineItemEditorMenu} = pageflow.timelinePage;
+      const {Measure} = pageflow.react.components;
 
       return (
-        <div className={this._className()}>
-          <div className="timeline_item_spacer-inner" style={this._style()} />
-          <TimelineItemEditorMenu pageLink={this.props.pageLink}
-                                  top={this._menuTop()}
-                                  onDrag={this._handleDrag.bind(this)}
-                                  onDragStop={this._handleDragStop.bind(this)}/>
-        </div>
+        <Measure whitelist={['width']}>
+          { ({width}) =>
+            <div className={this._className()}>
+              <div className="timeline_item_spacer-inner" style={this._style()} />
+              <TimelineItemEditorMenu pageLink={this.props.pageLink}
+                                      top={this._menuTop(width)}
+                                      onDrag={this._handleDrag.bind(this)}
+                                      onDragStop={top => this._handleDragStop(top, width)}/>
+            </div>
+          }
+        </Measure>
       );
-    }
-
-    pageDidActivate() {
-      this._measure();
-    }
-
-    pageDidResize() {
-      this._measure();
     }
 
     _className() {
@@ -50,12 +47,8 @@
       }
     }
 
-    _menuTop() {
-      if (this.state.width) {
-        return this.state.width * (this.props.pageLink.top || 0) / 100;
-      }
-
-      return 0;
+    _menuTop(width) {
+      return width * (this.props.pageLink.top || 0) / 100;
     }
 
     _isDragging() {
@@ -69,23 +62,15 @@
       });
     }
 
-    _handleDragStop(top) {
+    _handleDragStop(top, width) {
       this.setState({
         dragging: false
       });
-
-      var width = ReactDOM.findDOMNode(this).offsetWidth;
 
       this.props.updatePageLink({
         linkId: this.props.pageLink.id,
         name: 'top',
         value: top / width * 100
-      });
-    }
-
-    _measure() {
-      this.setState({
-        width: ReactDOM.findDOMNode(this).offsetWidth
       });
     }
   }

--- a/pageflow-timeline-page.gemspec
+++ b/pageflow-timeline-page.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'pageflow', '~> 12.0.pre'
+  spec.add_dependency 'pageflow', ['>= 12.0.0.rc6', '< 13']
 
   # Using translations from rails locales in javascript code.
   spec.add_dependency 'i18n-js'


### PR DESCRIPTION
Update to API of `react-draggable` to 2.x, which comes with Pageflow
12. `start`/`moveOnStartChange` have been removed in `react-draggable`
1.0. Use controlled `Draggable` instead by keeping the position in the
menu component's state.

Use `react-measure` instead of custom measuring logic.