### PR TITLE
Disable image positioning for custom link thumbnail

### DIFF
--- a/app/assets/javascripts/pageflow/timeline_page/editor.js
+++ b/app/assets/javascripts/pageflow/timeline_page/editor.js
@@ -47,6 +47,7 @@ pageflow.editor.pageTypes.register('timeline_page', {
         this.group('page_link');
 
         this.input('thumbnail_image_id', pageflow.FileInputView, {
+          positioning: false,
           collection: 'image_files',
           fileSelectionHandler: 'pageLink'
         });


### PR DESCRIPTION
Thumbnails are cropped during image processing. No positioning is
possible after the fact.

REDMINE-13174